### PR TITLE
fix(errors): change how config errors are displayed

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -66,14 +66,16 @@ export function initEngine(presets) {
 }
 
 export function exec(filePath, fileText) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     try {
       linting = true;
       allowUnsafeNewFunction(() => {
         resolve(engine.executeOnText(fileText, filePath));
       });
     } catch (error) {
-      reject(error);
+      // Rather than displaying a big error, treat the error as a normal lint error so it shows
+      // in the footer rather than a pop-up toast error message.
+      resolve({ results: [{ messages: [{ line: 1, message: error, ruleId: NaN, severity: 2 }] }] });
     } finally {
       linting = false;
     }


### PR DESCRIPTION
Change how config errors are displayed.
Rather than rejecting the promise, which results in an Atom toast error message, treat the error like a lint error and display it in the footer.
This becomes far less annoying when opening projects that don't include an .eslintrc.json file.

Fixes #166